### PR TITLE
chore: upgrade action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: 'Indicates if extracted values should be masked in GitHub action logs'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
## Summary

- Updates `action.yml` to use `node24` instead of `node20` as the action runtime

## Motivation

Node.js 20 is deprecated on GitHub Actions runners:
- Actions will be **forced to run with Node.js 24 by default starting June 2, 2026**
- Node.js 20 will be **removed from the runner on September 16, 2026**

This is a one-line change with no code modifications required — the existing JavaScript is fully compatible with Node.js 24.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/